### PR TITLE
Lock threads for cutouts

### DIFF
--- a/arrakis/cutout.py
+++ b/arrakis/cutout.py
@@ -3,17 +3,15 @@
 
 import argparse
 import logging
-import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
-import os
-import multiprocessing as mp
 from pathlib import Path
 from pprint import pformat
 from shutil import copyfile
 from typing import List
 from typing import NamedTuple as Struct
 from typing import Optional, Set, TypeVar
+from threading import Lock
 
 import astropy.units as u
 import numpy as np
@@ -117,6 +115,7 @@ def cutout_weight(
 
 
 def cutout_image(
+    lock: Lock,
     image_name: Path,
     data_in_mem: np.ndarray,
     old_header: fits.Header,
@@ -198,19 +197,15 @@ def cutout_image(
     # Add source name to header for CASDA
     fixed_header["OBJECT"] = source_id
     if not dryrun:
-        if outfile.exists():
-            time.sleep(1)
-            outfile.unlink(missing_ok=True)
-            time.sleep(1)
-
-        fits.writeto(
-            outfile,
-            sub_data,
-            header=fixed_header,
-            overwrite=True,
-            output_verify="fix",
-        )
-        logger.info(f"Written to {outfile}")
+        with lock:
+            fits.writeto(
+                outfile,
+                sub_data,
+                header=fixed_header,
+                overwrite=True,
+                output_verify="fix",
+            )
+            logger.info(f"Written to {outfile}")
 
     filename = outfile.parent / outfile.name
     newvalues = {
@@ -334,7 +329,8 @@ def get_args(
     )
 
 
-def worker(
+def make_cutout(
+    lock: Lock,
     host: str,
     epoch: int,
     source: pd.Series,
@@ -360,6 +356,7 @@ def worker(
         outdir=outdir,
     )
     image_update = cutout_image(
+        lock=lock,
         image_name=image_name,
         data_in_mem=data_in_mem,
         old_header=old_header,
@@ -423,14 +420,15 @@ def big_cutout(
         sources = sources[:limit]
 
     # Check for slurm cpus
-    max_workers = int(os.environ.get("SLURM_CPUS_PER_TASK", mp.cpu_count()))
     updates: List[pymongo.UpdateOne] = []
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    lock = Lock()
+    with ThreadPoolExecutor() as executor:
         futures = []
         for _, source in sources.iterrows():
             futures.append(
                 executor.submit(
-                    worker,
+                    make_cutout,
+                    lock=lock,
                     host=host,
                     epoch=epoch,
                     source=source,

--- a/arrakis/cutout.py
+++ b/arrakis/cutout.py
@@ -346,6 +346,7 @@ def make_cutout(
     pad: float = 3,
     username: Optional[str] = None,
     password: Optional[str] = None,
+    dryrun: bool = False,
 ):
     _, _, comp_col = get_db(
         host=host, epoch=epoch, username=username, password=password
@@ -367,7 +368,7 @@ def make_cutout(
         beam_num=beam_num,
         stoke=stoke,
         pad=pad,
-        dryrun=False,
+        dryrun=dryrun,
     )
     weight_update = cutout_weight(
         image_name=image_name,
@@ -376,7 +377,7 @@ def make_cutout(
         field=field,
         beam_num=beam_num,
         stoke=stoke,
-        dryrun=False,
+        dryrun=dryrun,
     )
     return [image_update, weight_update]
 
@@ -396,6 +397,7 @@ def big_cutout(
     username: Optional[str] = None,
     password: Optional[str] = None,
     limit: Optional[int] = None,
+    dryrun: bool = False,
 ) -> List[pymongo.UpdateOne]:
     wild = f"image.restored.{stoke.lower()}*contcube*beam{beam_num:02}.conv.fits"
     images = list(datadir.glob(wild))
@@ -444,6 +446,7 @@ def big_cutout(
                     pad=pad,
                     username=username,
                     password=password,
+                    dryrun=dryrun,
                 )
             )
         for future in tqdm(futures, file=TQDM_OUT, desc=f"Cutting {image_name}"):
@@ -570,6 +573,7 @@ def cutout_islands(
                 username=username,
                 password=password,
                 limit=limit,
+                dryrun=dryrun,
             )
             cuts.append(results)
 


### PR DESCRIPTION
We have repeatedly hit errors like the following
```
  File "/datasets/work/sa-mhongoose/work/mambaforge/envs/arrakis310/lib/python3.10/site-packages/arrakis/cutout.py", line 360, in worker
    image_update = cutout_image(
  File "/datasets/work/sa-mhongoose/work/mambaforge/envs/arrakis310/lib/python3.10/site-packages/arrakis/cutout.py", line 204, in cutout_image
    fits.writeto(
  File "/datasets/work/sa-mhongoose/work/mambaforge/envs/arrakis310/lib/python3.10/site-packages/astropy/io/fits/convenience.py", line 464, in writeto
    hdu.writeto(
  File "/datasets/work/sa-mhongoose/work/mambaforge/envs/arrakis310/lib/python3.10/site-packages/astropy/io/fits/hdu/base.py", line 412, in writeto
    hdulist.writeto(name, output_verify, overwrite=overwrite, checksum=checksum)
  File "/datasets/work/sa-mhongoose/work/mambaforge/envs/arrakis310/lib/python3.10/site-packages/astropy/io/fits/hdu/hdulist.py", line 1031, in writeto
    fileobj = _File(fileobj, mode=mode, overwrite=overwrite)
  File "/datasets/work/sa-mhongoose/work/mambaforge/envs/arrakis310/lib/python3.10/site-packages/astropy/io/fits/file.py", line 218, in __init__
    self._open_filename(fileobj, mode, overwrite)
  File "/datasets/work/sa-mhongoose/work/mambaforge/envs/arrakis310/lib/python3.10/site-packages/astropy/io/fits/file.py", line 640, in _open_filename
    self._overwrite_existing(overwrite, None, True)
  File "/datasets/work/sa-mhongoose/work/mambaforge/envs/arrakis310/lib/python3.10/site-packages/astropy/io/fits/file.py", line 521, in _overwrite_existing
    os.remove(self.name)
FileNotFoundError: [Errno 2] No such file or directory: '/scratch3/projects/spiceracs/processing/56614_arrakis/cutouts/RACS_1837-09_3951/RACS_1837-09_3951.cutout.image.restored.q.RACS_1837-09.contcube.beam14.conv.fits
```
Even though an `ls` shows the file _does_ exist, or ahead of runtime the file didn't exist. Whether this is a quirk of the Lustre filesystem, a lack of thread-safety in `astropy.io`, both, or something else is not clear.

What has solved the issue, though, is to hold a threadlock around the `fits.write` functions.
Great success.